### PR TITLE
New bounds

### DIFF
--- a/integration_tests/test_stack_integrated.py
+++ b/integration_tests/test_stack_integrated.py
@@ -238,7 +238,7 @@ def test_z_bounds(render, teststack, render_example_tilespec_and_transforms):
     zbounds = render.run(renderapi.stack.get_bounds_from_z,
                          teststack, tilespecs[0].z)
 
-    expected_bounds = {u'maxZ': 3407.0, u'maxX': 4918.0, u'maxY': 4506.0,
+    expected_bounds = {u'maxZ': 3407.0, u'maxX': 4918.0, u'maxY': 4507.0,
                        u'minX': 149.0, u'minY': 130.0, u'minZ': 3407.0}
     for key in zbounds.keys():
         assert np.abs(zbounds[key]-expected_bounds[key]) < 1.0

--- a/integration_tests/test_stack_integrated.py
+++ b/integration_tests/test_stack_integrated.py
@@ -225,7 +225,7 @@ def teststack(request, render, render_example_tilespec_and_transforms):
 def test_stack_bounds(render, teststack):
     # check the stack bounds
     stack_bounds = render.run(renderapi.stack.get_stack_bounds, teststack)
-    expected_bounds = {u'maxZ': 3408.0, u'maxX': 5102.0, u'maxY': 5385.0,
+    expected_bounds = {u'maxZ': 3408.0, u'maxX': 5103.0, u'maxY': 5385.0,
                        u'minX': 149.0, u'minY': 130.0, u'minZ': 3407.0}
 
     for key in stack_bounds.keys():
@@ -238,7 +238,7 @@ def test_z_bounds(render, teststack, render_example_tilespec_and_transforms):
     zbounds = render.run(renderapi.stack.get_bounds_from_z,
                          teststack, tilespecs[0].z)
 
-    expected_bounds = {u'maxZ': 3407.0, u'maxX': 4917.0, u'maxY': 4506.0,
+    expected_bounds = {u'maxZ': 3407.0, u'maxX': 4918.0, u'maxY': 4506.0,
                        u'minX': 149.0, u'minY': 130.0, u'minZ': 3407.0}
     for key in zbounds.keys():
         assert np.abs(zbounds[key]-expected_bounds[key]) < 1.0

--- a/integration_tests/test_stack_integrated.py
+++ b/integration_tests/test_stack_integrated.py
@@ -225,7 +225,7 @@ def teststack(request, render, render_example_tilespec_and_transforms):
 def test_stack_bounds(render, teststack):
     # check the stack bounds
     stack_bounds = render.run(renderapi.stack.get_stack_bounds, teststack)
-    expected_bounds = {u'maxZ': 3408.0, u'maxX': 5103.0, u'maxY': 5385.0,
+    expected_bounds = {u'maxZ': 3408.0, u'maxX': 5103.0, u'maxY': 5386.0,
                        u'minX': 149.0, u'minY': 130.0, u'minZ': 3407.0}
 
     for key in stack_bounds.keys():

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open('requirements.txt', 'r') as f:
     required = f.read().splitlines()
 
 setup(name='render-python',
-      version='1.3.0',
+      version='1.4.0',
       description=' a python API to interact via python with render '
                   'databases see https://github.com/saalfeldlab/render',
       author='Forrest Collman, Russel Torres, Eric Perlman, Sharmi Seshamani',


### PR DESCRIPTION
This fixes the tests with the new version of render, whose stack bounds calculation was changed, and so the enforced tests were wrong.