### PR TITLE
Changed metadata to metaData to get persistence of transform labels w…

### DIFF
--- a/integration_tests/test_stack_integrated.py
+++ b/integration_tests/test_stack_integrated.py
@@ -34,7 +34,7 @@ def render():
 @pytest.fixture
 def simpletilespec():
     mml = renderapi.tilespec.MipMapLevel(0, '/not/a/path.jpg')
-    tform = renderapi.transform.AffineModel(labels='simple')
+    tform = renderapi.transform.AffineModel(labels=['simple'])
     layout = renderapi.tilespec.Layout(sectionId="section0",
                                        scopeId="testscope",
                                        cameraId="testcamera",

--- a/renderapi/transform.py
+++ b/renderapi/transform.py
@@ -367,7 +367,7 @@ class Transform(object):
         if self.transformId is not None:
             d['id'] = self.transformId
         if self.labels is not None:
-            d['metadata'] = {'labels': self.labels}
+            d['metaData'] = {'labels': self.labels}
         return d
 
     def from_dict(self, d):
@@ -381,7 +381,7 @@ class Transform(object):
         self.className = d['className']
         self.transformId = d.get('id', None)
         self._process_dataString(d['dataString'])
-        md = d.get('metadata', None)
+        md = d.get('metaData', None)
         if md is not None:
             self.labels = md.get('labels', None)
         else:


### PR DESCRIPTION
…orking.  Although I now realize metadata is the proper spelling, the camel case version has been propagated too widely across the render code base to quickly correct it.  Hopefully this doesn't offend anyone's sensibilities too much (if it does, let me know).