### PR TITLE
image pyramid interface update

### DIFF
--- a/integration_tests/test_image_open.py
+++ b/integration_tests/test_image_open.py
@@ -1,0 +1,25 @@
+import renderapi
+from renderapi.image_open import read_mipmap_image, read_mipmap_mask
+from test_data import render_params, test_2_channels_d
+import pytest
+import numpy as np
+
+@pytest.fixture(scope='module')
+def test_mml():
+    tilespecs = [renderapi.tilespec.TileSpec(json=d) for d in test_2_channels_d]
+    mml = tilespecs[0].channels[0].ip[0]
+    return mml
+
+def test_image_open(test_mml):
+    img = read_mipmap_image(test_mml)
+    assert (img.shape == (2048,2048))
+    assert (img.dtype == np.uint16)
+    assert (img.max() == 23059)
+
+def test_mask_open(test_mml):
+    mask = read_mipmap_mask(test_mml)
+    assert (mask.shape == (2048,2048))
+    assert (mask.dtype == np.uint8)
+    assert (mask.max() == np.iinfo(mask.dtype).max)
+
+    

--- a/renderapi/channel.py
+++ b/renderapi/channel.py
@@ -35,7 +35,7 @@ class Channel:
             d['minIntensity']=self.minIntensity
         if self.maxIntensity is not None:
             d['maxIntensity']=self.maxIntensity
-        d['mipmapLevels'] = self.ip.to_ordered_dict()
+        d['mipmapLevels'] = dict(self.ip)
         return d
     
     def from_dict(self,d):
@@ -49,8 +49,6 @@ class Channel:
         self.name=d['name']
         self.minIntensity=d['minIntensity']
         self.maxIntensity=d['maxIntensity']
-        self.ip = ImagePyramid(mipMapLevels=[
-            MipMapLevel(
+        self.ip = ImagePyramid({l:MipMapLevel(
                 int(l), imageUrl=v.get('imageUrl'), maskUrl=v.get('maskUrl'))
-            for l, v in d['mipmapLevels'].items()])
-    
+            for l, v in d['mipmapLevels'].items()})

--- a/renderapi/image_open.py
+++ b/renderapi/image_open.py
@@ -1,0 +1,94 @@
+
+try:
+    from urlparse import urlparse
+    from urllib import unquote, urlopen
+except ImportError as e:
+    from urllib.parse import urlparse, unquote 
+    from urllib.request import urlopen
+import tifffile
+import numpy as np
+import os
+from PIL import Image
+import boto3
+import tempfile
+import io
+
+def read_mipmap_image(mml,apply_mask=False):
+    """function to read a raw image from a mipmaplevel 
+
+    Parameters
+    ==========
+    mml : renderapi.image_pyramid.MipMapLevel
+        mip map level to read image of
+    apply_mask: bool
+        whether to apply mask to image (default=False)
+    
+    Returns
+    =======
+    numpy.array
+        numpy array of image
+    """
+    img= read_image_url(mml.imageUrl)
+    if apply_mask:
+        mask = read_mipmap_mask(mml)
+        mask = np.array(mask,dtype=np.float)/np.max(mask)
+        img = np.array(img*mask,dtype=img.dtype)
+    return img
+
+def read_mipmap_mask(mml):
+    """function to read mask from a mipmaplevel
+
+    Parameters
+    ==========
+    mml : renderapi.image_pyramid.MipMapLevel
+        mipmaplevel to read image from
+
+    Returns
+    =======
+    numpy.array
+        numpy array of mask
+    """
+    return read_image_url(mml.maskUrl)
+
+def read_image_url(url):
+    """function to read in a render url to an image to a numpy array
+
+    Parameters
+    ==========
+    url: str or unicode
+        url to image to read
+    dtype: numpy.dtype or None
+        dtype to convert image to (default to our judgement)
+
+    Returns
+    =======
+    numpy.array
+        an numpy array containing the image data
+    """
+    (scheme, netloc, path, params, query, fragment) = urlparse(url)
+    filepath = unquote(path)
+    filetype = os.path.splitext(filepath)[1][1:]
+    
+    if (scheme == 'file') or (scheme == ''):
+        if filetype == 'tif':
+            array = tifffile.imread(filepath)
+        else:
+            with open(filepath, 'r') as fp:
+                array = np.asarray(Image.open(fp))
+
+    if (scheme == 'http') or (scheme == 'https'):
+        with urlopen(url) as fp:
+            array = np.asarray(Image.open(fp))
+    if (scheme == 's3'):
+        client = boto3.client('s3')
+        path=path[1:]
+        if filetype == 'tif':
+            fp,tfile = tempfile.mkstemp()
+            client.download_file(netloc, path, tfile)
+            array = tifffile.imread(tfile)
+            os.remove(tfile)
+        else:
+            obj = client.get_object(Bucket=netloc,Key=path)
+            array = np.asarray(Image.open(io.BytesIO(obj['Body'].read())))
+
+    return array

--- a/renderapi/tilespec.py
+++ b/renderapi/tilespec.py
@@ -91,7 +91,7 @@ class TileSpec:
             self.inputfilters = inputfilters
             self.layout = Layout(**kwargs) if layout is None else layout
 
-            self.ip = ImagePyramid(mipMapLevels=mipMapLevels)
+            self.ip = ImagePyramid({mml.level:mml for mml in mipMapLevels})
             # legacy scaleXUrl
             self.maskUrl = maskUrl
             self.imageUrl = imageUrl
@@ -136,7 +136,7 @@ class TileSpec:
         thedict['maxIntensity'] = self.maxint
         if self.layout is not None:
             thedict['layout'] = self.layout.to_dict()
-        thedict['mipmapLevels'] = self.ip.to_ordered_dict()
+        thedict['mipmapLevels'] = dict(self.ip)
         thedict['transforms'] = {}
         thedict['transforms']['type'] = 'list'
         # thedict['transforms']['specList']=[t.to_dict() for t in self.tforms]
@@ -188,10 +188,9 @@ class TileSpec:
         self.maxY = d.get('maxY', None)
         self.minY = d.get('minY', None)
         mmld = d.get('mipmapLevels',{})
-        self.ip = ImagePyramid(mipMapLevels=[
-            MipMapLevel(
+        self.ip = ImagePyramid({l:MipMapLevel(
                 int(l), imageUrl=v.get('imageUrl'), maskUrl=v.get('maskUrl'))
-            for l, v in mmld.items()])
+            for l, v in mmld.items()})
 
         tfl = TransformList(json=d['transforms'])
         self.tforms = tfl.tforms

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ dill>=0.2.6
 pathos
 sphinxcontrib-napoleon
 decorator
+tifffile
+boto3

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open('requirements.txt', 'r') as f:
     required = f.read().splitlines()
 
 setup(name='render-python',
-      version='1.5.0',
+      version='2.0.0',
       description=' a python API to interact via python with render '
                   'databases see https://github.com/saalfeldlab/render',
       author='Forrest Collman, Russel Torres, Eric Perlman, Sharmi Seshamani',

--- a/test/test_channel.py
+++ b/test/test_channel.py
@@ -18,7 +18,8 @@ def test_channel():
     mml = renderapi.image_pyramid.MipMapLevel(0,
                                               imageUrl='file:///not/a/path',
                                               maskUrl='file:///not/a/mask')
-    ip = renderapi.image_pyramid.ImagePyramid(mipMapLevels=[mml])
+    ip = renderapi.image_pyramid.ImagePyramid()
+    ip[0]=mml
     channel = renderapi.channel.Channel(name='DAPI',
                                         maxIntensity=255,
                                         minIntensity=0,

--- a/test/test_resolvedtiles.py
+++ b/test/test_resolvedtiles.py
@@ -24,7 +24,7 @@ def resolvedtiles_object(referenced_tilespecs_and_transforms):
 
 def test_resolvedtiles_from_dict(resolvedtiles_object,referenced_tilespecs_and_transforms):
     tilespecs,transforms = referenced_tilespecs_and_transforms
-    d=resolvedtiles_object.to_dict()
+    d=json.loads(renderapi.utils.renderdumps(resolvedtiles_object))
     resolved_tiles = renderapi.resolvedtiles.ResolvedTiles(json=d)
     assert(len(tilespecs)==len(resolved_tiles.tilespecs))
     assert(len(transforms)==len(resolved_tiles.transforms))


### PR DESCRIPTION
This is a proposal for a breaking change to the api of the image pyramid class that would implement it as an implementation of an abstract MutableMapping interface.  It would make it so that image pyramid would act as a dictionary of MipMapLevels, where ip[0] and ip["0"] would return the same thing, and only positive integers would be accepted as valid keys.   This is a breaking change, but it would simplify a lot of the interactions with mipmaplevels for code that is changing or adding images.

In addition I implemented an image_open module which uses this interface to simplify the reading in of images specified in MipMapLevels, regardless of where those images are eventually stored.  This is an independent module that i'm not auto-importing.  I could imagine this is a separate pull request.. open to feedback there.