### PR TITLE
Renderclientaccess

### DIFF
--- a/renderapi/client.py
+++ b/renderapi/client.py
@@ -8,15 +8,71 @@ from functools import partial
 import logging
 import subprocess
 import tempfile
+from decorator import decorator
 from .errors import ClientScriptError
-from .utils import NullHandler, renderdump_temp
-from .render import RenderClient, renderaccess
+from .utils import NullHandler, renderdump_temp, fitargspec
+from .render import RenderClient, renderaccess, Render
 from .stack import set_stack_state, make_stack_params
 from pathos.multiprocessing import ProcessingPool as Pool
 
 # setup logger
 logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())
+
+
+@decorator
+def renderclientaccess(f, *args, **kwargs):
+    """Decorator allowing functions asking for host, port, owner, project,
+    client_script to default to a connection defined by :class:`RenderClient`
+    object using its :func:`RenderClient.make_kwargs` method.
+    Will also attempt to derive a :class:`RenderClient` from an input
+    :class:`Render` object and fail if client scripts cannot be reached.
+
+    Parameters
+    ----------
+    f : func
+        function to decorate
+    Returns
+    -------
+    obj
+        output of decorated function
+    """
+    args, kwargs = fitargspec(f, args, kwargs)
+    render = kwargs.get('render')
+    if render is not None:
+        if not isinstance(render, RenderClient):
+            if isinstance(render, Render):
+                render = RenderClient(**render.make_kwargs(**kwargs))
+            else:
+                raise ValueError(
+                    'invalid RenderClient object type {} specified!'.format(
+                        type(render)))
+        return f(*args, **render.make_kwargs(**kwargs))
+    else:
+        try:
+            client_script = kwargs.get('client_script')
+            cs_valid = os.path.isfile(client_script)
+        except TypeError as e:
+            try:
+                if os.path.isdir(kwargs.get('client_scripts')):
+                    client_script = os.path.join(client_scripts,
+                                                 'run_ws_client.sh')
+                    cs_valid = os.path.isfile(client_script)
+                else:
+                    raise ClientScriptError(
+                        'invalid client_scripts directory {}'.format(
+                            kwargs.get('client_scripts')))
+            except TypeError as e:
+                raise ClientScriptError(
+                    'No client script information specified: '
+                    'client_scripts={} client_script={}'.format(
+                        kwargs.get('client_scripts'),
+                        kwargs.get('client_script')))
+        if not cs_valid:
+            # TODO should also check for executability
+            raise ClientScriptError(
+                'invalid client script: {} not a file'.format(client_script))
+    return f(*args, **kwargs)
 
 
 class WithPool(Pool):
@@ -42,7 +98,7 @@ class WithPool(Pool):
         super(WithPool, self)._clear()
 
 
-@renderaccess
+@renderclientaccess
 def import_single_json_file(stack, jsonfile, transformFile=None,
                             client_scripts=None, host=None, port=None,
                             owner=None, project=None, render=None, **kwargs):
@@ -77,7 +133,7 @@ def import_single_json_file(stack, jsonfile, transformFile=None,
     logger.debug(proc.stdout.read())
 
 
-@renderaccess
+@renderclientaccess
 def import_jsonfiles_and_transforms_parallel_by_z(
         stack, jsonfiles, transformfiles, poolsize=20,
         client_scripts=None, host=None, port=None, owner=None,
@@ -117,7 +173,7 @@ def import_jsonfiles_and_transforms_parallel_by_z(
         set_stack_state(stack, 'COMPLETE', host, port, owner, project)
 
 
-@renderaccess
+@renderclientaccess
 def import_jsonfiles_parallel(
         stack, jsonfiles, poolsize=20, transformFile=None,
         client_scripts=None, host=None, port=None, owner=None,
@@ -198,7 +254,7 @@ def import_jsonfiles(stack, jsonfiles, transformFile=None,
         set_stack_state(stack, 'COMPLETE', host, port, owner, project)
 
 
-@renderaccess
+@renderclientaccess
 def import_jsonfiles_validate_client(stack, jsonfiles,
                                      transformFile=None, client_scripts=None,
                                      host=None, port=None, owner=None,
@@ -249,7 +305,7 @@ def import_jsonfiles_validate_client(stack, jsonfiles,
         set_stack_state(stack, 'COMPLETE', host, port, owner, project)
 
 
-@renderaccess
+@renderclientaccess
 def import_tilespecs(stack, tilespecs, sharedTransforms=None,
                      subprocess_mode=None, host=None, port=None,
                      owner=None, project=None, client_script=None,
@@ -285,7 +341,7 @@ def import_tilespecs(stack, tilespecs, sharedTransforms=None,
         os.remove(trjson)
 
 
-@renderaccess
+@renderclientaccess
 def import_tilespecs_parallel(stack, tilespecs, sharedTransforms=None,
                               subprocess_mode=None, poolsize=20,
                               close_stack=True, host=None, port=None,
@@ -329,7 +385,7 @@ def import_tilespecs_parallel(stack, tilespecs, sharedTransforms=None,
 
 
 # TODO handle fromJson and toJson persistence in these calls
-@renderaccess
+@renderclientaccess
 def local_to_world_array(stack, points, tileId, subprocess_mode=None,
                          host=None, port=None, owner=None, project=None,
                          client_script=None, memGB=None,
@@ -355,7 +411,7 @@ def local_to_world_array(stack, points, tileId, subprocess_mode=None,
     raise NotImplementedError('Whoops')
 
 
-@renderaccess
+@renderclientaccess
 def world_to_local_array(stack, points, subprocess_mode=None,
                          host=None, port=None, owner=None, project=None,
                          client_script=None, memGB=None,
@@ -443,7 +499,7 @@ def get_param(var, flag):
     return ([flag, var] if var is not None else [])
 
 
-@renderaccess
+@renderclientaccess
 def importJsonClient(stack, tileFiles=None, transformFile=None,
                      subprocess_mode=None,
                      host=None, port=None, owner=None, project=None,
@@ -473,7 +529,7 @@ def importJsonClient(stack, tileFiles=None, transformFile=None,
                        client_script=client_script, memGB=memGB)
 
 
-@renderaccess
+@renderclientaccess
 def tilePairClient(stack, minz, maxz, outjson=None, delete_json=False,
                    baseowner=None, baseproject=None, basestack=None,
                    xyNeighborFactor=None, zNeighborDistance=None,
@@ -584,7 +640,7 @@ def tilePairClient(stack, minz, maxz, outjson=None, delete_json=False,
     return jsondata
 
 
-@renderaccess
+@renderclientaccess
 def importTransformChangesClient(stack, targetStack, transformFile,
                                  targetOwner=None, targetProject=None,
                                  changeMode=None, close_stack=True,
@@ -642,7 +698,7 @@ def importTransformChangesClient(stack, targetStack, transformFile,
         set_stack_state(stack, 'COMPLETE', host, port, owner, project)
 
 
-@renderaccess
+@renderclientaccess
 def coordinateClient(stack, z, fromJson=None, toJson=None, localToWorld=None,
                      numberOfThreads=None, subprocess_mode=None,
                      host=None, port=None, owner=None,
@@ -688,7 +744,7 @@ def coordinateClient(stack, z, fromJson=None, toJson=None, localToWorld=None,
     return jsondata
 
 
-@renderaccess
+@renderclientaccess
 def renderSectionClient(stack, rootDirectory, zs, scale=None,
                         maxIntensity=None, minIntensity=None, format=None,
                         doFilter=None, fillWithNoise=None,
@@ -734,7 +790,7 @@ def renderSectionClient(stack, rootDirectory, zs, scale=None,
                        subprocess_mode=subprocess_mode, add_args=argvs)
 
 
-@renderaccess
+@renderclientaccess
 def transformSectionClient(stack, transformId, transformClass, transformData,
                            zValues, targetProject=None, targetStack=None,
                            replaceLast=None, subprocess_mode=None,

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import renderapi
 import rendersettings
 
@@ -9,6 +10,8 @@ args = {
     'project': 'renderproject',
     'client_scripts': '/path/to/client_scripts'
     }
+
+
 def test_render_client():
     r = renderapi.render.connect(**args)
 
@@ -51,14 +54,112 @@ def test_environment_variables_client():
         renvkwargs=rendersettings.DEFAULT_RENDER_CLIENT_ENVIRONMENT_VARIABLES,
         validate_client=False)
 
-@renderapi.render.renderaccess
-def my_decorated(myparameter, owner=None, host=None, port=None,
-              project=None,client_scripts=None, **kwargs):
-    return (owner,host,port,project,client_scripts)
 
-def test_decorator():
+@renderapi.render.renderaccess
+def renderaccess_decorated(myparameter, owner=None, host=None, port=None,
+                           project=None, client_scripts=None, **kwargs):
+    return (owner, host, port, project, client_scripts)
+
+
+@renderapi.client.renderclientaccess
+def renderclientaccess_decorated(myparameter, owner=None, host=None,
+                                 port=None, project=None,
+                                 client_scripts=None, client_script=None,
+                                 **kwargs):
+    return (owner, host, port, project, client_scripts, client_script)
+
+
+def test_decorator(my_decorated=renderaccess_decorated):
     r = renderapi.render.connect(**args)
-    (owner,host,port,project,client_scripts)=my_decorated(5,render=r)
+    (owner, host, port, project, client_scripts) = my_decorated(5, render=r)
     assert(owner == args['owner'])
-    (owner,host,port,project,client_scripts)=my_decorated(5,owner='newowner',render=r)
-    assert(owner == 'newowner')  
+    (owner, host, port, project, client_scripts) = my_decorated(
+        5, owner='newowner', render=r)
+    assert(owner == 'newowner')
+
+
+def test_renderaccess_decorator(tmpdir):
+    def checkexpected(expectation, values):
+        return all([i == j for i, j in zip(expectation, values)])
+
+    newargs = dict(args, **{'client_scripts': str(tmpdir)})
+
+    assert not os.path.isfile(
+        renderapi.render.RenderClient.clientscript_from_clientscripts(
+            str(tmpdir)))
+
+    expected = (newargs['owner'], newargs['host'], newargs['port'],
+                newargs['project'], newargs['client_scripts'],
+                renderapi.render.RenderClient.clientscript_from_clientscripts(
+                    newargs['client_scripts']))
+
+    with open(renderapi.render.RenderClient.clientscript_from_clientscripts(
+            str(tmpdir)), 'w') as f:
+        # test that renderclientaccess decorated funtion works with Render
+        #     objects missing client_script
+        assert checkexpected(expected, renderclientaccess_decorated(
+            5, render=renderapi.render.Render(**newargs)))
+        # test that RenderClient objects continue to work
+        assert checkexpected(expected, renderclientaccess_decorated(
+            5, render=renderapi.render.RenderClient(**newargs)))
+        # test with renderapi.connect set RenderObjects
+        assert checkexpected(expected, renderclientaccess_decorated(
+            5, render=renderapi.connect(force_http=False, **newargs)))
+
+    os.remove(renderapi.render.RenderClient.clientscript_from_clientscripts(
+            str(tmpdir)))
+
+
+def test_renderclientaccess_decorator_fail(tmpdir):
+    # test that common methods of defining renderclient options fail quickly
+    newargs = dict(args, **{'client_scripts': str(tmpdir)})
+
+    assert not os.path.isfile(
+        renderapi.render.RenderClient.clientscript_from_clientscripts(
+            str(tmpdir)))
+
+    with pytest.raises(renderapi.errors.ClientScriptError):
+        _ = renderclientaccess_decorated(
+            5, render=renderapi.render.Render(**newargs))
+
+    with pytest.raises(renderapi.errors.ClientScriptError):
+        _ = renderclientaccess_decorated(
+            5, render=renderapi.render.RenderClient(**newargs))
+
+    with pytest.raises(renderapi.errors.ClientScriptError):
+        _ = renderclientaccess_decorated(
+            5, render=renderapi.connect(force_http=False, **newargs))
+
+
+def test_renderclientaccess_override(tmpdir):
+    def checkexpected(expectation, values):
+        return all([i == j for i, j in zip(expectation, values)])
+
+    newargs = dict(args, **{'client_scripts': str(tmpdir)})
+
+    assert not os.path.isfile(
+        renderapi.render.RenderClient.clientscript_from_clientscripts(
+            str(tmpdir)))
+
+    expected = ('newowner', newargs['host'], newargs['port'],
+                newargs['project'], newargs['client_scripts'],
+                renderapi.render.RenderClient.clientscript_from_clientscripts(
+                    newargs['client_scripts']))
+
+    with open(renderapi.render.RenderClient.clientscript_from_clientscripts(
+            str(tmpdir)), 'w') as f:
+        # test that renderclientaccess decorated funtion works with Render
+        #     objects missing client_script
+        assert checkexpected(expected, renderclientaccess_decorated(
+            5, owner='newowner', render=renderapi.render.Render(**newargs)))
+        # test that RenderClient objects continue to work
+        assert checkexpected(expected, renderclientaccess_decorated(
+            5, owner='newowner',
+            render=renderapi.render.RenderClient(**newargs)))
+        # test with renderapi.connect set RenderObjects
+        assert checkexpected(expected, renderclientaccess_decorated(
+            5, owner='newowner',
+            render=renderapi.connect(force_http=False, **newargs)))
+
+    os.remove(renderapi.render.RenderClient.clientscript_from_clientscripts(
+            str(tmpdir)))


### PR DESCRIPTION
Adds renderclientaccess decorator to fail quickly before, e.g., spinning up multiprocessing pools.  I haven't looked at this for a bit, so I will give it a once-over as well.