### PR TITLE
tests: allow RENDERAPP_EXAMPLE_DATA to override RENDER_EXAMPLE_DATA

### DIFF
--- a/integration_tests/test_data.py
+++ b/integration_tests/test_data.py
@@ -8,6 +8,7 @@ def render_json_template(env, template_file, **kwargs):
     return d
 
 example_dir = os.environ.get('RENDER_EXAMPLE_DATA','/var/www/render/examples/')
+renderapp_example_dir = os.environ.get('RENDERAPP_EXAMPLE_DATA', example_dir)
 
 test_files_dir = os.path.join(os.path.dirname(__file__), 'test_files')
 example_env = Environment(loader=FileSystemLoader(test_files_dir))
@@ -31,9 +32,8 @@ tilespec_file = os.path.join(example_dir,'example_1','cycle1_step1_acquire_tiles
 tform_file = os.path.join(example_dir,'example_1','cycle1_step1_acquire_transforms.json')
 test_pool_size = os.environ.get('RENDER_PYTHON_TEST_POOL_SIZE',3)
 
-multi_channel_dir = os.path.join(example_dir,'multichannel-test')
+multi_channel_dir = os.path.join(renderapp_example_dir, 'multichannel-test')
 
 test_2_channels_d = render_json_template(example_env,
     'test_2_channels.json',
     multi_channel_example_dir=multi_channel_dir)
-


### PR DESCRIPTION
 to allow non-deployment integration testing