### PR TITLE
utils: allow ujson for requests calls if it can be imported

### DIFF
--- a/renderapi/utils.py
+++ b/renderapi/utils.py
@@ -7,8 +7,18 @@ import logging
 import inspect
 import copy
 import json
-from .errors import RenderError
+
 import numpy
+import requests
+
+from .errors import RenderError
+
+# use ujson if installed for faster json
+try:
+    import ujson as requests_json
+except ImportError:
+    import json as requests_json
+requests.models.complexjson = requests_json
 
 
 class NullHandler(logging.Handler):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,4 +8,5 @@ pytest-xdist>=1.14
 flake8>=3.0.4
 pylint>=1.5.4
 scipy
+ujson
 jinja2


### PR DESCRIPTION
overwrites default json handler for requests model with ujson if it is importable.

in testing cjson, simplejson, standard json, and ujson, ujson was the clear winner in all trials where there was a difference -- this seems to confirm what the internet has to say about the issue as well.  This change should resolve #78 to a reasonable degree while not altering the code in the library.