### PR TITLE
making affine properties correct for Similarity

### DIFF
--- a/renderapi/transform/leaf/affine_models.py
+++ b/renderapi/transform/leaf/affine_models.py
@@ -49,7 +49,7 @@ class AffineModel(Transform):
     className = 'mpicbg.trakem2.transform.AffineModel2D'
 
     def __init__(self, M00=1.0, M01=0.0, M10=0.0, M11=1.0, B0=0.0, B1=0.0,
-                 transformId=None, labels=None, json=None):
+                 transformId=None, labels=None, json=None, force_shear='x'):
         """Initialize AffineModel, defaulting to identity
 
         Parameters
@@ -88,6 +88,7 @@ class AffineModel(Transform):
             self.labels = labels
             self.load_M()
             self.transformId = transformId
+            self.force_shear = force_shear
 
     @property
     def dataString(self):
@@ -302,21 +303,48 @@ class AffineModel(Transform):
         pt = np.dot(np.linalg.inv(self.M), points.T).T
         return self.convert_points_vector_to_array(pt, Nd)
 
+    def calc_properties(self):
+        if self.force_shear == 'x':
+            sy = np.sqrt(self.M[1, 0] ** 2 + self.M[1, 1] ** 2)
+            theta = np.arctan2(self.M[1, 0], self.M[1, 1])
+            rc = np.cos(theta)
+            rs = np.sin(theta)
+            sx = rc * self.M[0, 0] - rs * self.M[0, 1]
+            if rs != 0:
+                cx = (self.M[0, 0] - sx*rc) / (sx * rs)
+            else:
+                cx = (self.M[0, 1] - sx*rs) / (sx * rc)
+            cy = 0.0
+        else:
+            # shear in y direction
+            sx = np.sqrt(self.M[0, 0] ** 2 + self.M[0, 1] ** 2)
+            theta = np.arctan2(-self.M[0, 1], self.M[0, 0])
+            rc = np.cos(theta)
+            rs = np.sin(theta)
+            sy = rs * self.M[1, 0] + rc * self.M[1, 1]
+            if rs != 0:
+                cy = (self.M[1, 1] - sy * rc) / (-sy * rs)
+            else:
+                cy = (self.M[1, 0] - sy * rs) / (sy * rc)
+            cx = 0.0
+        # room for other cases, for example cx = cy
+
+        return sx, sy, cx, cy, theta
+
     @property
     def scale(self):
         """tuple of scale for x, y"""
-        return tuple([np.sqrt(sum([i ** 2 for i in self.M[j, 0:2]]))
-                      for j in range(self.M.shape[0])])[:2]
+        sx, sy, cx, cy, theta = self.calc_properties()
+        return (sx, sy)
 
     @property
     def shear(self):
-        """tuple of shear coefficients"""
-        unrotate = np.array([
-            [np.cos(-self.rotation), -np.sin(-self.rotation), 0],
-            [np.sin(-self.rotation), np.cos(-self.rotation), 0],
-            [0, 0, 1]])
-        Mun = self.M.dot(unrotate)
-        return (Mun[0, 1], Mun[1, 0])
+        """shear"""
+        sx, sy, cx, cy, theta = self.calc_properties()
+        if self.force_shear == 'x':
+            return cx
+        else:
+            return cy
 
     @property
     def translation(self):
@@ -326,9 +354,8 @@ class AffineModel(Transform):
     @property
     def rotation(self):
         """counter-clockwise rotation"""
-        return 0.5*(
-                np.arctan2(self.M[1, 0], self.M[1, 1]) -
-                np.arctan2(self.M[0, 1], self.M[0, 0]))
+        sx, sy, cx, cy, theta = self.calc_properties()
+        return theta
 
     def __str__(self):
         return "M=[[%f,%f],[%f,%f]] B=[%f,%f]" % (

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -635,6 +635,23 @@ def test_affine_properties():
     cx = 0.0
     cy = 0.0
     # angle
+    theta = 0.0
+    pt = np.array(
+        [1.234, 4.567, 1])
+    M, testpt, rnd_tf = affine_property_function(sx, sy, cx, cy, theta, pt)
+    tformpt = rnd_tf.tform(np.array([pt[0:2]]))
+    assert np.all(np.abs(M - rnd_tf.M) < 1e-8)
+    assert np.all(np.abs(testpt[0:2] - tformpt) < 1e-8)
+    assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+           (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    assert np.abs(rnd_tf.rotation - theta) < 1e-8
+    assert (np.abs(rnd_tf.shear - cx) < 1e-8)
+    rnd_tf.force_shear = 'y'
+    assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+           (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    assert np.abs(rnd_tf.rotation - theta) < 1e-8
+    assert (np.abs(rnd_tf.shear - cx) < 1e-8)
+
     theta = 0.1234
     pt = np.array(
         [1.234, 4.567, 1])

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -627,7 +627,7 @@ def test_similarity_init():
     assert(tform.M[0, 2] == 10)
 
 
-def test_similarity_properties():
+def test_affine_properties():
     # scale
     sx = 1.5
     sy = 1.1
@@ -638,7 +638,81 @@ def test_similarity_properties():
     theta = 0.1234
     pt = np.array(
         [1.234, 4.567, 1])
+    M, testpt, rnd_tf = affine_property_function(sx, sy, cx, cy, theta, pt)
+    tformpt = rnd_tf.tform(np.array([pt[0:2]]))
+    assert np.all(np.abs(M - rnd_tf.M) < 1e-8)
+    assert np.all(np.abs(testpt[0:2] - tformpt) < 1e-8)
+    assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+           (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    assert np.abs(rnd_tf.rotation - theta) < 1e-8
+    assert (np.abs(rnd_tf.shear - cx) < 1e-8)
+    rnd_tf.force_shear = 'y'
+    assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+           (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    assert np.abs(rnd_tf.rotation - theta) < 1e-8
+    assert (np.abs(rnd_tf.shear - cx) < 1e-8)
 
+    cx = 0.2
+    cy = 0.0
+    M, testpt, rnd_tf = affine_property_function(sx, sy, cx, cy, theta, pt)
+    tformpt = rnd_tf.tform(np.array([pt[0:2]]))
+    assert np.all(np.abs(M - rnd_tf.M) < 1e-8)
+    assert np.all(np.abs(testpt[0:2] - tformpt) < 1e-8)
+    assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+           (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    assert np.abs(rnd_tf.rotation - theta) < 1e-8
+    assert (np.abs(rnd_tf.shear - cx) < 1e-8)
+
+    rnd_tf.force_shear = 'y'
+    with pytest.raises(AssertionError):
+        assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+               (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    with pytest.raises(AssertionError):
+        assert np.abs(rnd_tf.rotation - theta) < 1e-8
+
+    cx = 0.0
+    cy = 0.1
+    M, testpt, rnd_tf = affine_property_function(sx, sy, cx, cy, theta, pt)
+    tformpt = rnd_tf.tform(np.array([pt[0:2]]))
+    assert np.all(np.abs(M - rnd_tf.M) < 1e-8)
+    assert np.all(np.abs(testpt[0:2] - tformpt) < 1e-8)
+    with pytest.raises(AssertionError):
+        assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+               (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    with pytest.raises(AssertionError):
+        assert np.abs(rnd_tf.rotation - theta) < 1e-8
+
+    rnd_tf.force_shear = 'y'
+    assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+           (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    assert np.abs(rnd_tf.rotation - theta) < 1e-8
+    assert (np.abs(rnd_tf.shear - cy) < 1e-8)
+
+    cx = 0.3
+    cy = 0.1
+    M, testpt, rnd_tf = affine_property_function(sx, sy, cx, cy, theta, pt)
+    tformpt = rnd_tf.tform(np.array([pt[0:2]]))
+    assert np.all(np.abs(M - rnd_tf.M) < 1e-8)
+    assert np.all(np.abs(testpt[0:2] - tformpt) < 1e-8)
+    with pytest.raises(AssertionError):
+        assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+               (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    with pytest.raises(AssertionError):
+        assert np.abs(rnd_tf.rotation - theta) < 1e-8
+    with pytest.raises(AssertionError):
+        assert (np.abs(rnd_tf.shear - cx) < 1e-8)
+
+    rnd_tf.force_shear = 'y'
+    with pytest.raises(AssertionError):
+        assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
+               (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
+    with pytest.raises(AssertionError):
+        assert np.abs(rnd_tf.rotation - theta) < 1e-8
+    with pytest.raises(AssertionError):
+        assert (np.abs(rnd_tf.shear - cy) < 1e-8)
+
+
+def affine_property_function(sx, sy, cx, cy, theta, pt):
     scale = np.array([
         [sx, 0, 0],
         [0, sy, 0],
@@ -660,15 +734,7 @@ def test_similarity_properties():
             M01=M[0, 1],
             M10=M[1, 0],
             M11=M[1, 1])
-    tformpt = rnd_tf.tform(np.array([pt[0:2]]))
-
-    assert np.all(np.abs(M - rnd_tf.M) < 1e-8)
-    assert np.all(np.abs(testpt[0:2] - tformpt) < 1e-8)
-    assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
-           (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
-    assert np.abs(rnd_tf.rotation - theta) < 1e-8
-    assert (np.abs(rnd_tf.shear[0] - cx) < 1e-8) & \
-           (np.abs(rnd_tf.shear[1] - cy) < 1e-8)
+    return M, testpt, rnd_tf
 
 
 def test_thinplatespline_inverse():

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -628,10 +628,13 @@ def test_similarity_init():
 
 
 def test_similarity_properties():
+    # scale
     sx = 1.5
     sy = 1.1
+    # shear
     cx = 0.0
     cy = 0.0
+    # angle
     theta = 0.1234
     pt = np.array(
         [1.234, 4.567, 1])


### PR DESCRIPTION
the premise of this PR is that for a SimilarityModel, (scalex, scaley, rotation) are uniquely defined by M[0:2, 0:2] and those unique correct values should be returned. They were not correct.
Similarly, (scalex, scaley, shearx, sheary, rotation) are not uniquely defined for an AffineModel, at least one with non-zero shear. (5 unknowns, 4 equations).
You can see the incorrect behavior from here:
```
import renderapi
import numpy as np

def test_tform(sx, sy, cx, cy, theta, pt):
    scale = np.array([
        [sx, 0, 0],
        [0, sy, 0],
        [0, 0, 1]])
    shear = np.array([
        [1, cx, 0],
        [cy, 1, 0],
        [0, 0, 1]])
    rotation = np.array([
        [np.cos(theta), -np.sin(theta), 0],
        [np.sin(theta), np.cos(theta), 0],
        [0, 0, 1]])
    M = scale.dot(shear.dot(rotation))

    testpt = M.dot(pt)[0:2]

    rnd_tf = renderapi.transform.SimilarityModel(
            M00 = M[0, 0],
            M01 = M[0, 1],
            M10 = M[1, 0],
            M11 = M[1, 1])
    tformpt = rnd_tf.tform(np.array([pt[0:2]]))

    try:
        assert np.all(np.abs(M - rnd_tf.M) < 1e-8)
        print(' yes, M = rnd_tf.M')
    except AssertionError:
        print('Assertion Error')
        print('  M     = \n', M)
        print('  rnd_tf.M = \n', rnd_tf.M)

    try:
        assert np.all(np.abs(testpt[0:2] - tformpt) < 1e-8)
        print(' yes, testpt = tformpt')
    except AssertionError:
        print('  testpt: \n', testpt[0:2])
        print('  tformpt: \n', tformpt[0:2])

    try:
        assert (np.abs(rnd_tf.scale[0] - sx) < 1e-8) & \
               (np.abs(rnd_tf.scale[1] - sy) < 1e-8)
        print(' yes, scales match')
    except AssertionError:
        print('Assertion Error')
        print('  (sx, sy)     = (%0.2f %0.2f)' % (sx, sy))
        print('  rnd_tf.scale = (%0.2f %0.2f)' % (rnd_tf.scale[0], rnd_tf.scale[1]))

    try:
        assert np.abs(rnd_tf.rotation - theta) < 1e-8
        print(' yes, thetas match')
    except AssertionError:
        print('Assertion Error')
        print('  theta           = %0.3f' % theta)
        print('  rnd_tf.rotation = %0.3f' % rnd_tf.rotation)

    try:
        assert (np.abs(rnd_tf.shear[0] - cx) < 1e-8) & \
               (np.abs(rnd_tf.shear[1] - cy) < 1e-8)
        print(' yes, shears match')
    except AssertionError:
        print('Assertion Error')
        print('  rnd_tf.shear:', rnd_tf.shear)


sx = 1.5
sy = 1.314
theta = 0.275
cx = 0.0
cy = 0.0

pt = np.array(
    [1.234, 4.567, 1])

print('no shear:')
test_tform(sx, sy, cx, cy, theta, pt)
```
```
(emtest_py2) danielk@ibs-danielk-ux1:~$ python test_rot.py 
no shear:
 yes, M = rnd_tf.M
 yes, testpt = tformpt
Assertion Error
  (sx, sy)     = (1.50 1.31)
  rnd_tf.scale = (1.49 1.33)
Assertion Error
  theta           = 0.275
  rnd_tf.rotation = 0.242
Traceback (most recent call last):
  File "test_rot.py", line 79, in <module>
    test_tform(sx, sy, cx, cy, theta, pt)
  File "test_rot.py", line 61, in test_tform
    assert (np.abs(rnd_tf.shear[0] - cx) < 1e-8) & \
IndexError: invalid index to scalar variable.
```
The 2 AssertionErrors were due to [i, j] mix up in calculating scale and rotation.
The IndexError is because I changed shear to return a (cx, cy) tuple, though, any of these quantities coming back from an AffineModel with shear are not unique.