### PR TITLE
adding __pycache__ and pyc to docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 docker_setup.sh
 docker_base_setup.sh
+**/__pycache__
+**/*.pyc


### PR DESCRIPTION
I think sometimes periodic failures of the build pipeline are because the bamboo directory gets filled with things written by root and then the next build can't copy them into the docker.  This addition will both fix this, and make our docker image a bit smaller.