### PR TITLE
Pass render import ts parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
         - libopenblas-base
         - libopenblas-dev
         - gfortran
-        - oracle-java8-set-default
+        - oracle-java9-set-default
         - maven
 install:
   - pip install codecov

--- a/renderapi/client/client.py
+++ b/renderapi/client/client.py
@@ -300,7 +300,7 @@ def import_tilespecs_parallel(stack, tilespecs, sharedTransforms=None,
         import_tilespecs, stack, sharedTransforms=sharedTransforms,
         subprocess_mode=subprocess_mode, host=host, port=port,
         owner=owner, project=project, client_script=client_script,
-        memGB=memGB, **kwargs)
+        render=render, memGB=memGB, **kwargs)
 
     # TODO this is a weird way to do splits.... is that okay?
     tilespec_groups = [g for g in

--- a/renderapi/stack.py
+++ b/renderapi/stack.py
@@ -704,8 +704,8 @@ def get_sectionId_for_z(stack, z, host=None, port=None, owner=None,
 
     Returns
     -------
-    float
-        z value of sectionId
+    str 
+        value of sectionId
 
     Raises
     ------


### PR DESCRIPTION
for EMaligner, I was trying to get rid of the need of cloning render and installing java in the Travis builds. The only java client the aligner uses is via `import_tilespecs_parallel`. We should have been able to go javaless by setting `validate_client=False` and setting `use_rest=True`. That worked for `import_tilespecs` but not for `import_tilespecs_parallel`. It was still throwing:
```
ClientScriptError: invalid client script: run_ws_client.sh not a file
```
I've confirmed that this change lets the EMaligner build go javaless.