### PR TITLE
remove session object from being created on import

### DIFF
--- a/renderapi/coordinate.py
+++ b/renderapi/coordinate.py
@@ -20,7 +20,7 @@ logger.addHandler(NullHandler())
 @renderaccess
 def world_to_local_coordinates(stack, z, x, y, host=None,
                                port=None, owner=None, project=None,
-                               session=requests.session(),
+                               session=None,
                                render=None, **kwargs):
     """maps an world x,y,z coordinate in stack to a local coordinate
     Parameters
@@ -64,7 +64,7 @@ def world_to_local_coordinates(stack, z, x, y, host=None,
 @renderaccess
 def local_to_world_coordinates(stack, tileId, x, y,
                                host=None, port=None, owner=None, project=None,
-                               session=requests.session(),
+                               session=None,
                                render=None, **kwargs):
     """convert coordinate from local to world with webservice request
 
@@ -110,7 +110,7 @@ def local_to_world_coordinates(stack, tileId, x, y,
 def world_to_local_coordinates_batch(stack, d, z, host=None,
                                      port=None, owner=None, project=None,
                                      execute_local=False,
-                                     session=requests.session(),
+                                     session=None,
                                      render=None, **kwargs):
 
     """convert coordinate parameters from world to local
@@ -174,7 +174,7 @@ def world_to_local_coordinates_batch(stack, d, z, host=None,
 @renderaccess
 def local_to_world_coordinates_batch(stack, d, z, host=None,
                                      port=None, owner=None, project=None,
-                                     session=requests.session(),
+                                     session=None,
                                      render=None, **kwargs):
     """convert coordinate parameters from local to world
 
@@ -302,7 +302,7 @@ def unpackage_world_to_local_point_match_from_json(json_answer, tileId):
 # def old_world_to_local_coordinates_array(stack, dataarray, tileId, z=0,
 #                                          host=None, port=None,
 #                                          owner=None, project=None,
-#                                          session=requests.session(),
+#                                          session=None,
 #                                          render=None, **kwargs):
 #     ''''''
 
@@ -359,7 +359,7 @@ def world_to_local_coordinates_array(stack, dataarray, tileId, z,
                                      owner=None, project=None,
                                      client_script=None,
                                      doClientSide=False, number_of_threads=20,
-                                     session=requests.session(), **kwargs):
+                                     session=None, **kwargs):
     """map world to local coordinates using numpy array
 
     Parameters
@@ -403,7 +403,7 @@ def world_to_local_coordinates_array(stack, dataarray, tileId, z,
 # def old_local_to_world_coordinates_array(stack, dataarray, tileId, z=0,
 #                                          host=None, port=None,
 #                                          owner=None, project=None,
-#                                          session=requests.session(),
+#                                          session=None,
 #                                          render=None, **kwargs):
 #     ''''''
 #     request_url = format_preamble(
@@ -439,7 +439,7 @@ def local_to_world_coordinates_array(stack, dataarray, tileId, z,
                                      owner=None, project=None,
                                      client_script=None,
                                      doClientSide=False, number_of_threads=20,
-                                     session=requests.session(), **kwargs):
+                                     session=None, **kwargs):
     """map local to world coordinates using numpy array
 
     Parameters

--- a/renderapi/coordinate.py
+++ b/renderapi/coordinate.py
@@ -6,7 +6,6 @@ from .render import format_preamble, renderaccess
 from .utils import NullHandler, renderdumps, renderdump, get_json
 from .client import coordinateClient
 from .errors import RenderError
-import requests
 import json
 import numpy as np
 import logging

--- a/renderapi/image.py
+++ b/renderapi/image.py
@@ -36,7 +36,7 @@ def get_bb_renderparams(stack, z, x, y, width, height, scale=1.0,
                         binaryMask=None, filter=None, filterListName=None,
                         convertToGray=None, excludeMask=None,
                         host=None, port=None, owner=None,
-                        project=None, session=requests.session(),
+                        project=None, session=None,
                         render=None, **kwargs):
 
     request_url = format_preamble(
@@ -63,7 +63,7 @@ def get_bb_image(stack, z, x, y, width, height, scale=1.0,
                  minIntensity=None, maxIntensity=None, binaryMask=None,
                  filter=None, maxTileSpecsToRender=None,
                  host=None, port=None, owner=None, project=None,
-                 img_format=None, session=requests.session(),
+                 img_format=None, session=None,
                  render=None, **kwargs):
     """render image from a bounding box defined in xy and return numpy array:
 
@@ -150,7 +150,7 @@ def get_tile_renderparams(
         filter=None, filterListName=None, excludeMask=None, convertToGray=None,
         binaryMask=None, host=None, port=None, owner=None,
         project=None, img_format=None,
-        session=requests.session(), render=None, **kwargs):
+        session=None, render=None, **kwargs):
     request_url = format_preamble(
         host, port, owner, project, stack) + \
         "/tile/%s/render-parameters" % (
@@ -182,7 +182,7 @@ def get_tile_image_data(stack, tileId, channel=None, normalizeForMatching=True,
                         minIntensity=None, maxIntensity=None,
                         filter=None, host=None, port=None, owner=None,
                         project=None, img_format=None,
-                        session=requests.session(), render=None, **kwargs):
+                        session=None, render=None, **kwargs):
     """render image from a tile with all transforms and return numpy array
 
     :func:`renderapi.render.renderaccess` decorated function
@@ -273,7 +273,7 @@ def get_section_renderparams(stack, z, binaryMask=None, channel=None,
                              filterListName=None, minIntensity=None,
                              maxIntensity=None, scale=None,
                              host=None, port=None, owner=None, project=None,
-                             session=requests.session(),
+                             session=None,
                              render=None, **kwargs):
     request_url = format_preamble(
         host, port, owner, project, stack) + "/z/{}/render-parameters".format(
@@ -299,7 +299,7 @@ def get_section_image(stack, z, scale=1.0, channel=None,
                       filter=False,
                       maxTileSpecsToRender=None, img_format=None,
                       host=None, port=None, owner=None, project=None,
-                      session=requests.session(),
+                      session=None,
                       render=None, **kwargs):
     """render an section of image
 
@@ -371,7 +371,7 @@ def get_section_image(stack, z, scale=1.0, channel=None,
 @renderaccess
 def get_renderparameters_image(renderparams, img_format=None,
                                host=None, port=None, owner=None,
-                               session=requests.session(),
+                               session=None,
                                render=None, **kwargs):
     try:
         image_ext = IMAGE_FORMATS[img_format]

--- a/renderapi/image.py
+++ b/renderapi/image.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import io
-import requests
 from PIL import Image
 import numpy as np
 import logging

--- a/renderapi/pointmatch.py
+++ b/renderapi/pointmatch.py
@@ -90,7 +90,7 @@ def swap_matchpair(match, copy=True):
 
 @renderaccess
 def get_matchcollection_owners(host=None, port=None,
-                               session=requests.session(),
+                               session=None,
                                render=None, **kwargs):
 
     """get all the matchCollection owners
@@ -121,7 +121,7 @@ def get_matchcollection_owners(host=None, port=None,
 
 @renderaccess
 def get_matchcollections(owner=None, host=None, port=None,
-                         session=requests.session(), render=None, **kwargs):
+                         session=None, render=None, **kwargs):
     """get all the matchCollections owned by owner
 
     :func:`renderapi.render.renderaccess` decorated function
@@ -153,7 +153,7 @@ def get_matchcollections(owner=None, host=None, port=None,
 
 @renderaccess
 def get_match_groupIds(matchCollection, owner=None, host=None,
-                       port=None, session=requests.session(),
+                       port=None, session=None,
                        render=None, **kwargs):
     """get all the groupIds in a matchCollection
 
@@ -190,7 +190,7 @@ def get_match_groupIds(matchCollection, owner=None, host=None,
 def get_matches_outside_group(matchCollection, groupId, mergeCollections=None,
                               stream=True,
                               owner=None, host=None,
-                              port=None, session=requests.session(),
+                              port=None, session=None,
                               render=None, **kwargs):
     """get all the matches outside a groupId in a matchCollection
     returns all matches where pGroupId == groupId and qGroupId != groupId
@@ -237,7 +237,7 @@ def get_matches_outside_group(matchCollection, groupId, mergeCollections=None,
 def get_matches_within_group(matchCollection, groupId, mergeCollections=None,
                              stream=True,
                              owner=None, host=None, port=None,
-                             session=requests.session(),
+                             session=None,
                              render=None, **kwargs):
     """get all the matches within a groupId in a matchCollection
     returns all matches where pGroupId == groupId and qGroupId == groupId
@@ -286,7 +286,7 @@ def get_matches_from_group_to_group(matchCollection, pgroup, qgroup,
                                     mergeCollections=None, stream=True,
                                     render=None, owner=None, host=None,
                                     port=None,
-                                    session=requests.session(), **kwargs):
+                                    session=None, **kwargs):
     """get all the matches between two specific groups
     returns all matches where pgroup == pGroupId and qgroup == qGroupId
     OR pgroup == qGroupId and qgroup == pGroupId
@@ -360,7 +360,7 @@ def get_matches_from_tile_to_tile(matchCollection, pgroup, pid,
                                   qgroup, qid, mergeCollections=None,
                                   render=None, owner=None,
                                   host=None, port=None,
-                                  session=requests.session(), **kwargs):
+                                  session=None, **kwargs):
     """get all the matches between two specific tiles
     returns all matches where
     pgroup == pGroupId and pid=pId and qgroup == qGroupId and qid == qId
@@ -415,7 +415,7 @@ def get_matches_with_group(matchCollection, pgroup, mergeCollections=None,
                            stream=True,
                            render=None, owner=None,
                            host=None, port=None,
-                           session=requests.session(), **kwargs):
+                           session=None, **kwargs):
     """get all the matches from a specific groups
     returns all matches where pgroup == pGroupId
 
@@ -461,7 +461,7 @@ def get_matches_with_group(matchCollection, pgroup, mergeCollections=None,
 def get_match_groupIds_from_only(matchCollection, mergeCollections=None,
                                  render=None, owner=None,
                                  host=None, port=None,
-                                 session=requests.session(), **kwargs):
+                                 session=None, **kwargs):
     """get all the source pGroupIds in a matchCollection
 
     :func:`renderapi.render.renderaccess` decorated function
@@ -499,7 +499,7 @@ def get_match_groupIds_from_only(matchCollection, mergeCollections=None,
 def get_match_groupIds_to_only(matchCollection, mergeCollections=None,
                                render=None, owner=None,
                                host=None, port=None,
-                               session=requests.session(), **kwargs):
+                               session=None, **kwargs):
     """get all the destination qGroupIds in a matchCollection
 
     :func:`renderapi.render.renderaccess` decorated function
@@ -538,7 +538,7 @@ def get_match_groupIds_to_only(matchCollection, mergeCollections=None,
 def get_matches_involving_tile(matchCollection, groupId, id,
                                mergeCollections=None, stream=True,
                                owner=None, host=None, port=None,
-                               session=requests.session(), **kwargs):
+                               session=None, **kwargs):
     """get all the matches involving a specific tile
      returns all matches where groupId == pGroupId and id == pId
      OR groupId == qGroupId and id == qId
@@ -586,7 +586,7 @@ def get_matches_involving_tile(matchCollection, groupId, id,
 @renderaccess
 def delete_point_matches_between_groups(matchCollection, pGroupId, qGroupId,
                                         render=None, owner=None, host=None,
-                                        port=None, session=requests.session(),
+                                        port=None, session=None,
                                         **kwargs):
     """delete all the matches between two specific groups
     deletes all matches where (pgroup == pGroupId and qgroup == qGroupId)
@@ -631,7 +631,7 @@ def delete_point_matches_between_groups(matchCollection, pGroupId, qGroupId,
 
 @renderaccess
 def import_matches(matchCollection, data, owner=None, host=None, port=None,
-                   session=requests.session(), render=None, **kwargs):
+                   session=None, render=None, **kwargs):
     """import matches into render database
 
     :func:`renderapi.render.renderaccess` decorated function
@@ -664,7 +664,7 @@ def import_matches(matchCollection, data, owner=None, host=None, port=None,
 
 @renderaccess
 def delete_collection(matchCollection, owner=None, host=None, port=None,
-                      session=requests.session(), render=None, **kwargs):
+                      session=None, render=None, **kwargs):
     """delete match collection from render database
 
     :func:`renderapi.render.renderaccess` decorated function

--- a/renderapi/pointmatch.py
+++ b/renderapi/pointmatch.py
@@ -2,7 +2,6 @@
 '''
 Point Match APIs
 '''
-import requests
 import logging
 from .render import format_baseurl, renderaccess
 from .utils import NullHandler, get_json, put_json, rest_delete

--- a/renderapi/render.py
+++ b/renderapi/render.py
@@ -379,6 +379,9 @@ def renderaccess(f, *args, **kwargs):
     You can if you wish specify any of the arguments, in which case they
     will not be filled in by the default values, but you don't have to.
 
+    The default value for session is None, which will be replaced with a newly
+    created requests.Session object.
+
     As such, the documentation omits describing the parameters which are
     natural to expect will be filled in by the renderaccess decorator.
 
@@ -400,13 +403,17 @@ def renderaccess(f, *args, **kwargs):
     render = kwargs.get('render')
     if render is not None:
         if isinstance(render, Render):
-            return f(*args, **render.make_kwargs(**kwargs))
+            kwargs = render.make_kwargs(**kwargs)
         else:
             raise ValueError(
                 'invalid Render object type {} specified!'.format(
                     type(render)))
-    else:
-        return f(*args, **kwargs)
+
+    session = kwargs.get("session")
+    if session is None:
+        kwargs["session"] = requests.Session()
+
+    return f(*args, **kwargs)
 
 
 def format_baseurl(host, port):
@@ -459,7 +466,7 @@ def format_preamble(host, port, owner, project, stack):
 
 
 @renderaccess
-def get_owners(host=None, port=None, session=requests.session(),
+def get_owners(host=None, port=None, session=None,
                render=None, **kwargs):
     """return list of owners across all Projects and Stacks for a render server
 
@@ -488,7 +495,7 @@ def get_owners(host=None, port=None, session=requests.session(),
 
 @renderaccess
 def get_stack_metadata_by_owner(owner=None, host=None, port=None,
-                                session=requests.session(),
+                                session=None,
                                 render=None, **kwargs):
     """return metadata for all stacks belonging to particular
         owner on render server
@@ -517,7 +524,7 @@ def get_stack_metadata_by_owner(owner=None, host=None, port=None,
 
 @renderaccess
 def get_projects_by_owner(owner=None, host=None, port=None,
-                          session=requests.session(), render=None, **kwargs):
+                          session=None, render=None, **kwargs):
     """return list of projects belonging to a single owner for render stack
 
     :func:`renderaccess` decorated function
@@ -545,7 +552,7 @@ def get_projects_by_owner(owner=None, host=None, port=None,
 
 @renderaccess
 def get_stacks_by_owner_project(owner=None, project=None, host=None,
-                                port=None, session=requests.session(),
+                                port=None, session=None,
                                 render=None, **kwargs):
     """return list of stacks belonging to an owner's project on render server
 

--- a/renderapi/render.py
+++ b/renderapi/render.py
@@ -32,17 +32,25 @@ class Render(object):
         render client scripts path to which make_kwargs will default
     session : requests.sessions.Session
         session object to which make_kwargs will default
+    create_session : bool
+        create a new session for this instance of render if no session was
+        provided, allowing the same session to be reused for requests and
+        increasing performance, defaults to True
 
     """
 
     def __init__(self, host=None, port=None, owner=None, project=None,
-                 client_scripts=None, session=None, **kwargs):
+                 client_scripts=None, session=None, create_session=True,
+                 **kwargs):
         self.DEFAULT_HOST = host
         self.DEFAULT_PORT = port
         self.DEFAULT_PROJECT = project
         self.DEFAULT_OWNER = owner
         self.DEFAULT_CLIENT_SCRIPTS = client_scripts
-        self.session = session
+        if create_session and session is None:
+            self.session = requests.Session()
+        else:
+            self.session = session
 
         logger.debug('Render object created with '
                      'host={h}, port={p}, project={pr}, '
@@ -155,6 +163,10 @@ class RenderClient(Render):
         render client scripts path to which make_kwargs will default
     session : requests.sessions.Session
         session object to which make_kwargs will default
+    create_session : bool
+        create a new session for this instance of render if no session was
+        provided, allowing the same session to be reused for requests and
+        increasing performance, defaults to True
     client_script : str
         location of wrapper script for java client with input same as Render
         java client's run_ws_client.sh

--- a/renderapi/resolvedtiles.py
+++ b/renderapi/resolvedtiles.py
@@ -83,7 +83,7 @@ def combine_resolvedtiles(rts_l):
 def put_tilespecs(stack, resolved_tiles=None, deriveData=True,
                   tilespecs=None, shared_transforms=None,
                   host=None, port=None, owner=None, project=None,
-                  session=requests.session(), render=None, **kwargs):
+                  session=None, render=None, **kwargs):
     """upload resolved tiles to the server
 
     :func:`renderapi.render.renderaccess` decorated function
@@ -125,7 +125,7 @@ def put_tilespecs(stack, resolved_tiles=None, deriveData=True,
 @renderaccess
 def get_resolved_tiles_from_z(stack, z, host=None, port=None,
                               owner=None, project=None,
-                              session=requests.session(),
+                              session=None,
                               render=None, **kwargs):
     """Get a set of ResolvedTiles from a specific z value.
     Returns a tuple of tilespecs and referenced transforms.

--- a/renderapi/resolvedtiles.py
+++ b/renderapi/resolvedtiles.py
@@ -5,7 +5,6 @@ from .utils import NullHandler, put_json, jbool, get_json
 from .render import format_preamble, renderaccess
 from .errors import RenderError
 import logging
-import requests
 
 logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())

--- a/renderapi/stack.py
+++ b/renderapi/stack.py
@@ -96,7 +96,7 @@ class StackVersion:
 
 @renderaccess
 def set_stack_metadata(stack, sv, host=None, port=None, owner=None,
-                       project=None, session=requests.session(),
+                       project=None, session=None,
                        render=None, **kwargs):
     """sets the stack metadata for a stack
 
@@ -126,7 +126,7 @@ def set_stack_metadata(stack, sv, host=None, port=None, owner=None,
 
 @renderaccess
 def get_full_stack_metadata(stack, host=None, port=None, owner=None,
-                            project=None, session=requests.session(),
+                            project=None, session=None,
                             render=None, **kwargs):
     """get stack metadata for stack
 
@@ -193,7 +193,7 @@ def get_stack_metadata(*args, **kwargs):
 @renderaccess
 def set_stack_state(stack, state='LOADING', host=None, port=None,
                     owner=None, project=None,
-                    session=requests.session(), render=None, **kwargs):
+                    session=None, render=None, **kwargs):
     """
     set state of selected stack.
 
@@ -237,7 +237,7 @@ def set_stack_state(stack, state='LOADING', host=None, port=None,
 
 @renderaccess
 def likelyUniqueId(host=None, port=None,
-                   session=requests.session(), render=None, **kwargs):
+                   session=None, render=None, **kwargs):
     """return hex-code nearly-unique id from render server
 
     :func:`renderapi.render.renderaccess` decorated function
@@ -292,7 +292,7 @@ def make_stack_params(host, port, owner, project, stack):
 
 @renderaccess
 def delete_stack(stack, host=None, port=None, owner=None,
-                 project=None, session=requests.session(),
+                 project=None, session=None,
                  render=None, **kwargs):
     """deletes a stack from render server
 
@@ -321,7 +321,7 @@ def delete_stack(stack, host=None, port=None, owner=None,
 
 @renderaccess
 def delete_section(stack, z, host=None, port=None, owner=None,
-                   project=None, session=requests.session(),
+                   project=None, session=None,
                    render=None, **kwargs):
     """removes a single z from a stack
 
@@ -352,7 +352,7 @@ def delete_section(stack, z, host=None, port=None, owner=None,
 
 @renderaccess
 def delete_tile(stack, tileId, host=None, port=None, owner=None,
-                project=None, session=requests.session(),
+                project=None, session=None,
                 render=None, **kwargs):
     """
     removes a tile from a stack
@@ -388,7 +388,7 @@ def create_stack(stack, cycleNumber=None, cycleStepNumber=None,
                  stackResolutionX=None, stackResolutionY=None,
                  stackResolutionZ=None, force_resolution=True,
                  host=None, port=None, owner=None, project=None,
-                 session=requests.session(), render=None, **kwargs):
+                 session=None, render=None, **kwargs):
     """creates a new stack
 
     :func:`renderapi.render.renderaccess` decorated function
@@ -448,7 +448,7 @@ def create_stack(stack, cycleNumber=None, cycleStepNumber=None,
 @renderaccess
 def rename_stack(stack, to_stack, to_project=None, to_owner=None,
                  host=None, port=None, owner=None, project=None,
-                 session=requests.session(), render=None, **kwargs):
+                 session=None, render=None, **kwargs):
     """
      :func:`renderapi.render.renderaccess` decorated function
 
@@ -541,7 +541,7 @@ def clone_stack(inputstack, outputstack, skipTransforms=False, toProject=None,
 
 @renderaccess
 def get_z_values_for_stack(stack, project=None, host=None, port=None,
-                           owner=None, session=requests.session(),
+                           owner=None, session=None,
                            render=None, **kwargs):
     """get a list of z values for which there are tiles in the stack
 
@@ -575,7 +575,7 @@ def get_z_values_for_stack(stack, project=None, host=None, port=None,
 # @renderaccess
 # def put_resolved_tilespecs(stack, json_dict, host=None, port=None,
 #                            owner=None, project=None,
-#                            session=requests.session(),
+#                            session=None,
 #                            render=None, **kwargs):
 #     request_url = format_preamble(
 #         host, port, owner, project, stack) + "/resolvedTiles"
@@ -585,7 +585,7 @@ def get_z_values_for_stack(stack, project=None, host=None, port=None,
 
 @renderaccess
 def get_bounds_from_z(stack, z, host=None, port=None, owner=None,
-                      project=None, session=requests.session(),
+                      project=None, session=None,
                       render=None, **kwargs):
     """get a bounds dictionary for a specific z
 
@@ -620,7 +620,7 @@ def get_bounds_from_z(stack, z, host=None, port=None, owner=None,
 
 @renderaccess
 def get_stack_bounds(stack, host=None, port=None, owner=None, project=None,
-                     session=requests.session(), render=None, **kwargs):
+                     session=None, render=None, **kwargs):
     """get bounds of a whole stack
 
     :func:`renderapi.render.renderaccess` decorated function
@@ -651,7 +651,7 @@ def get_stack_bounds(stack, host=None, port=None, owner=None, project=None,
 
 @renderaccess
 def get_tilebounds_for_z(stack, z, host=None, port=None, owner=None,
-                         project=None, session=requests.session(),
+                         project=None, session=None,
                          render=None, **kwargs):
     """returns the bounds for each tile associated with a particular z value
 
@@ -686,7 +686,7 @@ def get_tilebounds_for_z(stack, z, host=None, port=None, owner=None,
 
 @renderaccess
 def get_sectionId_for_z(stack, z, host=None, port=None, owner=None,
-                        project=None, session=requests.session(),
+                        project=None, session=None,
                         render=None, **kwargs):
     """returns the sectionId associated with a particular z value
 
@@ -726,7 +726,7 @@ def get_sectionId_for_z(stack, z, host=None, port=None, owner=None,
 
 @renderaccess
 def get_stack_sectionData(stack, host=None, port=None, owner=None,
-                          project=None, session=requests.session(),
+                          project=None, session=None,
                           render=None, **kwargs):
     """returns information about the sectionIds of each slice in stack
 
@@ -766,7 +766,7 @@ def get_stack_sectionData(stack, host=None, port=None, owner=None,
 
 @renderaccess
 def get_section_z_value(stack, sectionId, host=None, port=None,
-                        owner=None, project=None, session=requests.session(),
+                        owner=None, project=None, session=None,
                         render=None, **kwargs):
     """get the z value for a specific sectionId (string)
 
@@ -799,7 +799,7 @@ def get_section_z_value(stack, sectionId, host=None, port=None,
 
 @renderaccess
 def get_stack_tileIds(stack, host=None, port=None, owner=None, project=None,
-                      session=requests.session(), render=None, **kwargs):
+                      session=None, render=None, **kwargs):
     """get tileIds for a stack
 
     :func:`renderapi.render.renderaccess` decorated function

--- a/renderapi/stack.py
+++ b/renderapi/stack.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import logging
 from time import strftime
-import requests
 from .errors import RenderError
 from .utils import jbool, NullHandler, post_json, put_json, rest_delete
 from .render import (format_baseurl, format_preamble,
@@ -515,7 +514,6 @@ def clone_stack(inputstack, outputstack, skipTransforms=False, toProject=None,
     requests.session.response
         server response
     """
-    session = requests.session() if session is None else session
     sv = StackVersion(**kwargs)
     newstack_project = project
     qparams = {}

--- a/renderapi/tilespec.py
+++ b/renderapi/tilespec.py
@@ -259,7 +259,7 @@ class TileSpec:
 @renderaccess
 def get_tile_spec_renderparameters(stack, tile, host=None, port=None,
                                    owner=None, project=None,
-                                   session=requests.session(),
+                                   session=None,
                                    render=None, **kwargs):
     """renderapi call to get the render parameters of a specific tileId
 
@@ -293,7 +293,7 @@ def get_tile_spec_renderparameters(stack, tile, host=None, port=None,
 
 @renderaccess
 def get_tile_spec(stack, tile, host=None, port=None, owner=None,
-                  project=None, session=requests.session(),
+                  project=None, session=None,
                   render=None, **kwargs):
     """renderapi call to get a specific tilespec by tileId
     note that this will return a tilespec with resolved transform references
@@ -328,7 +328,7 @@ def get_tile_spec(stack, tile, host=None, port=None, owner=None,
 
 @renderaccess
 def get_tile_spec_raw(stack, tile, host=None, port=None, owner=None,
-                      project=None, session=requests.session(),
+                      project=None, session=None,
                       render=None, **kwargs):
     """renderapi call to get a specific tilespec by tileId
     note that this will return a tilespec without resolved transform references
@@ -362,7 +362,7 @@ def get_tile_spec_raw(stack, tile, host=None, port=None, owner=None,
 def get_tile_specs_from_minmax_box(stack, z, xmin, xmax, ymin, ymax,
                                    scale=1.0, host=None,
                                    port=None, owner=None, project=None,
-                                   session=requests.session(),
+                                   session=None,
                                    render=None, **kwargs):
     """renderapi call to get all tilespec that exist within a 2d bounding box
     specified with min and max x,y values
@@ -409,7 +409,7 @@ def get_tile_specs_from_minmax_box(stack, z, xmin, xmax, ymin, ymax,
 @renderaccess
 def get_tile_specs_from_box(stack, z, x, y, width, height,
                             scale=1.0, host=None, port=None, owner=None,
-                            project=None, session=requests.session(),
+                            project=None, session=None,
                             render=None, **kwargs):
     """renderapi call to get all tilespec that exist within a 2d bounding box
     specified with min x,y values and width, height
@@ -455,7 +455,7 @@ def get_tile_specs_from_box(stack, z, x, y, width, height,
 
 @renderaccess
 def get_tile_specs_from_z(stack, z, host=None, port=None,
-                          owner=None, project=None, session=requests.session(),
+                          owner=None, project=None, session=None,
                           render=None, **kwargs):
     """Get all TileSpecs in a specific z values. Returns referenced transforms.
 
@@ -492,7 +492,7 @@ def get_tile_specs_from_z(stack, z, host=None, port=None,
 @renderaccess
 def get_tile_specs_from_stack(stack, host=None, port=None,
                               owner=None, project=None,
-                              session=requests.session(),
+                              session=None,
                               render=None, **kwargs):
     """get flat list of tilespecs for stack using i for sl in l for i in sl
 

--- a/renderapi/tilespec.py
+++ b/renderapi/tilespec.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import logging
-import requests
 import numpy as np
 from .render import format_preamble, renderaccess
 from .utils import NullHandler, get_json
@@ -68,8 +67,9 @@ class TileSpec:
     def __init__(self, tileId=None, z=None, width=None, height=None,
                  imageUrl=None, maskUrl=None,
                  minint=0, maxint=65535, layout=None, tforms=None,
-                 labels=None, groupId=None, inputfilters=None, json=None, channels=None,
-                 mipMapLevels=None, imagePyramid=None, **kwargs):
+                 labels=None, groupId=None, inputfilters=None, json=None,
+                 channels=None, mipMapLevels=None, imagePyramid=None,
+                 **kwargs):
         if json is not None:
             self.from_dict(json)
         else:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import renderapi
 import rendersettings
+import requests
 
 args = {
     'host': 'renderhost',
@@ -17,6 +18,7 @@ def test_render_client():
 
 
 def test_default_kwargs(rkwargs=rendersettings.DEFAULT_RENDER, **kwargs):
+    rkwargs = dict(rkwargs, session=requests.Session())
     r = renderapi.connect(**dict(rkwargs, **kwargs))
     new_r = renderapi.connect(**dict(r.DEFAULT_KWARGS, **kwargs))
     assert(new_r.DEFAULT_KWARGS == r.DEFAULT_KWARGS == rkwargs)
@@ -36,7 +38,8 @@ def test_environment_variables(
     old_env = os.environ.copy()
     os.environ.update(valstostring(renvkwargs))
 
-    env_render = renderapi.connect(**kwargs)
+    rkwargs = dict(rkwargs, session=requests.Session())
+    env_render = renderapi.connect(session=rkwargs["session"], **kwargs)
 
     # restore environment
     os.environ.clear()


### PR DESCRIPTION
all renderaccess functions that use the requests library did so by using a "session" parameter in the function declaration, this parameter was given a default value like this: `session=requests.session()`
doing this executed this code on import, that is, when the library is imported and these functions declared each function will call requests.session() and store this object in the default parameter list.
this is quite annoying to deal with and causes unexpected behavior, like each function setting up its own connection persistence.
this behavior also contradicted the docstrings on for example renderapi/stack.py which says the default behavior is to start a new session, even though that was not true. (with the exception of clone_stack)

to fix this problem this pr removes all instances of `session=requests.session()` in declarations and brings its handling of requests more in line with expectations

I've divided this pr in separate commits:
1. replace all of the malformed function declarations and instead use the renderaccess decorator to create a new session when not provided
2. remove the unused requests imports and formatting changes
3. add the session object to the Render class, allowing for easier use
4. have the Render class default to creating a new session in order to allow reusing the session, restoring the performance lost when removing the reused session on import
5. have the clone_stack function not create a new session anymore, this is redundant with the new behavior

most important is the first commit, the others can be split off into separate prs if there is a concern that these changes would impact existing use of the library.